### PR TITLE
Created verification result report

### DIFF
--- a/xeda/plugins/lwc/flows/timing_and_verification.py
+++ b/xeda/plugins/lwc/flows/timing_and_verification.py
@@ -326,6 +326,7 @@ class VivadoSimVerification(VivadoSim, LWC):
         success_pat = re.compile(
             r"PASS \(0\): SIMULATION FINISHED after (?P<cycles>\d+) cycles at (?P<totaltime>.*)")
         name = self.settings.design.get('name', "<NO-NAME>")
+        results['success'] = True
         for rc in run_configs:
             rc_results = {}
             rc_generics = rc['generics']
@@ -353,9 +354,6 @@ class VivadoSimVerification(VivadoSim, LWC):
 
             results['TV:' + rc_name] = rc_results
 
-        
-        if results['success'] != False:
-            results['success'] = True
 
         success_file = self.results_dir / (name + '_verification_results.json')
         


### PR DESCRIPTION
Writes report file to Results/ folder for lwc verification flow. Failures also copy the failed testvectors.txt file for the failed test

```
{
    "success": true,
    "TV:kats_for_verification": {
        "PDI": "/nhome/LWC_Benchmarking/unrestricted_2021/Xoodyak_GMU2/KAT/v1/kats_for_verification/pdi.txt",
        "SDI": "/nhome/LWC_Benchmarking/unrestricted_2021/Xoodyak_GMU2/KAT/v1/kats_for_verification/sdi.txt",
        "DO": "/nhome/LWC_Benchmarking/unrestricted_2021/Xoodyak_GMU2/KAT/v1/kats_for_verification/do.txt"
    },
    "TV:blanket_hash_test": {
        "postreset_cycles": "3714",
        "total_sim_time": "37270000 ps",
        "PDI": "/nhome/LWC_Benchmarking/unrestricted_2021/Xoodyak_GMU2/KAT/v1/blanket_hash_test/pdi.txt",
        "SDI": "/nhome/LWC_Benchmarking/unrestricted_2021/Xoodyak_GMU2/KAT/v1/blanket_hash_test/sdi.txt",
        "DO": "/nhome/LWC_Benchmarking/unrestricted_2021/Xoodyak_GMU2/KAT/v1/blanket_hash_test/do.txt"
    }
}
```